### PR TITLE
Add support for solution images

### DIFF
--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -202,6 +202,9 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         ### preventing image from the index file at the moment
         if self.in_book_index:
             return
+        ### Skip solutions if we say to 
+        if "solution" in node.attributes['classes'] and self.jupyter_drop_solutions:
+            return
         uri = node.attributes["uri"]
         self.images.append(uri)             #TODO: list of image files
         if self.jupyter_download_nb_image_urlpath:

--- a/tests/base/solutions.rst
+++ b/tests/base/solutions.rst
@@ -34,3 +34,7 @@ when :math:`x \in [0,1]`
     ax.fill(x, y, zorder=10)
     ax.grid(True, zorder=5)
     plt.show()
+
+.. image:: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=
+    :class: solution
+    :alt: a small transparent pixel


### PR DESCRIPTION
Code blocks with the class "solution" can already optionally be hidden. This commit extends that functionality to images.